### PR TITLE
Fix Swagger API

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -97,7 +97,7 @@
 						"name": "User",
 						"description": "Location that we want to add to a user.",
 						"schema": {
-							"$ref": "#/definitions/user"
+							"$ref": "#/definitions/userlocation"
 						}
 					}
 				],
@@ -108,7 +108,7 @@
 					"200": {
 						"description": "Success",
 						"schema": {
-							"$ref": "#/definitions/user"
+							"$ref": "#/definitions/userlocation"
 						}
 					},
 					"400": {
@@ -154,6 +154,18 @@
 			"type": "array",
 			"items": {
 				"$ref": "#/definitions/user"
+			}
+		},
+		"userlocation": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "number"
+				},
+				"name": {
+					"type": "string"
+				},
+				"location": {"$ref": "#/definitions/location"}
 			}
 		}
 	}


### PR DESCRIPTION
- A typo in `application/json` was causing the POST requests to be sent with the wrong content type headers, and thus Express was not recognising them as JSON.
- The location sent to `/tracking/adduserlocation` is is added as an element to the list of locations, so needs to be a single point, not an array. 

Fixes issue #1 